### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ example using the [Twitter bootstrap CSS framework](http://getbootstrap.com/):
 					<li><a href="/">Home</a></li>
 				</ul>
 
-				<div class="navbar-right">
+				<div class="nav navbar-nav navbar-right">
 @yield('aimeos_head')
 				</div>
 			</div>


### PR DESCRIPTION
Add `nav navbar-nav` class to `navbar-right` to enable users easily add menu items with default bootstrap CSS rules to the right side of the navbar